### PR TITLE
Add require request body for listing secrets per scope

### DIFF
--- a/aws/secrets.go
+++ b/aws/secrets.go
@@ -101,12 +101,18 @@ func (a SecretsAPI) DeleteSecret(scope, key string) error {
 }
 
 // ListSecrets lists the secret keys that are stored at this scope
-func (a SecretsAPI) ListSecrets() ([]models.SecretMetadata, error) {
+func (a SecretsAPI) ListSecrets(scope string) ([]models.SecretMetadata, error) {
 	var secretsList struct {
 		Secrets []models.SecretMetadata `json:"secrets,omitempty" url:"secrets,omitempty"`
 	}
 
-	resp, err := a.Client.performQuery(http.MethodGet, "/secrets/list", nil, nil)
+	data := struct {
+		Scope string `json:"scope,omitempty" url:"scope,omitempty"`
+	}{
+		scope,
+	}
+
+	resp, err := a.Client.performQuery(http.MethodGet, "/secrets/list", data, nil)
 	if err != nil {
 		return secretsList.Secrets, err
 	}

--- a/azure/secrets.go
+++ b/azure/secrets.go
@@ -101,12 +101,18 @@ func (a SecretsAPI) DeleteSecret(scope, key string) error {
 }
 
 // ListSecrets lists the secret keys that are stored at this scope
-func (a SecretsAPI) ListSecrets() ([]models.SecretMetadata, error) {
+func (a SecretsAPI) ListSecrets(scope string) ([]models.SecretMetadata, error) {
 	var secretsList struct {
 		Secrets []models.SecretMetadata `json:"secrets,omitempty" url:"secrets,omitempty"`
 	}
 
-	resp, err := a.Client.performQuery(http.MethodGet, "/secrets/list", nil, nil)
+	data := struct {
+		Scope string `json:"scope,omitempty" url:"scope,omitempty"`
+	}{
+		scope,
+	}
+
+	resp, err := a.Client.performQuery(http.MethodGet, "/secrets/list", data, nil)
 	if err != nil {
 		return secretsList.Secrets, err
 	}


### PR DESCRIPTION
As per `https://docs.azuredatabricks.net/api/latest/secrets.html#list-secrets`, `/secrets/list` requires a request body (although the documentation is inconsistent in this regard)