### PR TITLE
Fixed Cluster struct to correctly map default_tags property from json response

### DIFF
--- a/azure/models/ClusterInfo.go
+++ b/azure/models/ClusterInfo.go
@@ -26,7 +26,7 @@ type ClusterInfo struct {
 	LastActivityTime       int64              `json:"last_activity_time,omitempty" url:"last_activity_time,omitempty"`
 	ClusterMemoryMb        int64              `json:"cluster_memory_mb,omitempty" url:"cluster_memory_mb,omitempty"`
 	ClusterCores           float32            `json:"cluster_cores,omitempty" url:"cluster_cores,omitempty"`
-	DefaultTags            []ClusterTag       `json:"default_tags,omitempty" url:"default_tags,omitempty"`
+	DefaultTags            map[string]string  `json:"default_tags,omitempty" url:"default_tags,omitempty"`
 	ClusterLogStatus       *LogSyncStatus     `json:"cluster_log_status,omitempty" url:"cluster_log_status,omitempty"`
 	TerminationReason      *TerminationReason `json:"termination_reason,omitempty" url:"termination_reason,omitempty"`
 }

--- a/azure/models/deepcopy_generated.go
+++ b/azure/models/deepcopy_generated.go
@@ -192,8 +192,10 @@ func (in *ClusterInfo) DeepCopyInto(out *ClusterInfo) {
 	}
 	if in.DefaultTags != nil {
 		in, out := &in.DefaultTags, &out.DefaultTags
-		*out = make([]ClusterTag, len(*in))
-		copy(*out, *in)
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
 	}
 	if in.ClusterLogStatus != nil {
 		in, out := &in.ClusterLogStatus, &out.ClusterLogStatus


### PR DESCRIPTION
Performing a Get on Cluster was throwing unmarshalled exception, seems the spec was wrong and the DefaultTags is not an array of ClusterTag at all, it is instead a dictionary of values.

Have updated the model and the re-generated the deepcopy

Think this should fix #2 

