### PR TITLE
Use global httpclient to fix port exhaustion

### DIFF
--- a/aws/client.go
+++ b/aws/client.go
@@ -10,6 +10,7 @@ type DBClient struct {
 // Init initializes the client
 func (c *DBClient) Init(option databricks.DBClientOption) DBClient {
 	c.Option = option
+	option.Init()
 	return *c
 }
 

--- a/azure/client.go
+++ b/azure/client.go
@@ -10,6 +10,7 @@ type DBClient struct {
 // Init initializes the client
 func (c *DBClient) Init(option databricks.DBClientOption) DBClient {
 	c.Option = option
+	option.Init()
 	return *c
 }
 

--- a/databricks.go
+++ b/databricks.go
@@ -18,13 +18,15 @@ type DBClientOption struct {
 	DefaultHeaders     map[string]string
 	InsecureSkipVerify bool
 	TimeoutSeconds     int
+	client             http.Client
 }
 
-func (o *DBClientOption) getHTTPClient() http.Client {
+// Init initializes the client
+func (o *DBClientOption) Init() {
 	if o.TimeoutSeconds == 0 {
 		o.TimeoutSeconds = 10
 	}
-	client := http.Client{
+	o.client = http.Client{
 		Timeout: time.Duration(time.Duration(o.TimeoutSeconds) * time.Second),
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{
@@ -32,7 +34,10 @@ func (o *DBClientOption) getHTTPClient() http.Client {
 			},
 		},
 	}
-	return client
+}
+
+func (o *DBClientOption) getHTTPClient() http.Client {
+	return o.client
 }
 
 func (o *DBClientOption) getAuthHeader() map[string]string {


### PR DESCRIPTION
This issue was discovered by our team while load testing the [Azure databricks operator](https://github.com/microsoft/azure-databricks-operator/). The summary of this issue can be found here: https://github.com/microsoft/azure-databricks-operator/issues/145

In addition to the load tests, we also verified the sockets were remaining open by creating a test locally in the SDK. This test queried a databricks API using the SDK synchronously 10 times, while we monitored the ports being used via a bash script. 

Before we applied the fix running the test below showed 10 connections created and in the `ESTABLISHED` state (note that these transition to `TIME_WAIT` when the process exits). With the changes in this PR, ports are re-used and we see fewer ports in the `ESTABLISHED` and `TIME_WAIT` states in the test.

The files for test can be found below:

``` go
func Test_MultipleCallsToAPI(t *testing.T) {

	// Setup before running:
	// - run  a real or mock databricks API
	// - set up the below test to connect to the API     
	// - run `watch -n  1 /tmp/netstat.sh` to monitor number of open connections (Will see 10 extra in ESTABLISHED state while paused which then switch to TIME_WAIT)
	// Goal: update the SDK to reuse connections so that the above conditions no longer occur :-)
	// (go clean -testcache && go test -v ./azure -run Test_MultipleCallsToAPI)
	// ( watch -n 1 ./netstat.sh  )

	// /tmp/netstat.sh:
	/*
		echo "ESTABLISHED: $(netstat -t | grep localhost | grep EST | wc -l)"
		echo "TIME_WAIT: $(netstat -t | grep localhost | grep TIME_WAIT | wc -l)"
		echo "TOTAL: $(netstat -t | grep localhost | wc -l)"
		echo "--------------"
		#netstat -t | grep localhost
	*/

	//Arrange
	var o databricks.DBClientOption
	o.Host = "http://localhost:8080"
	o.Token = "dummy - not checked by mock api"

	var c DBClient
	c.Init(o)

	//Act
	for index := 0; index < 10; index++ {
		_, err := c.Jobs().List()
		assert.Nil(t, err)
	}
	_ = "foo1"

	time.Sleep(30 * time.Second) // sleep to keep the process alive so that we can check the number of open sockets
}
```
``` bash
# netsat.sh
echo "ESTABLISHED: $(netstat -t | grep localhost | grep EST | wc -l)"
echo "TIME_WAIT: $(netstat -t | grep localhost | grep TIME_WAIT | wc -l)"
echo "TOTAL: $(netstat -t | grep localhost | wc -l)"
echo "--------------"
netstat -t | grep localhost
```

After we applied this fix in our fork, we ran also a secondary set of load tests to confirm that the change has had the desired effect. In the below chart, we can see the load tests happily run well past the previous crash point:

![image](https://user-images.githubusercontent.com/12761692/72060950-d8309080-32cc-11ea-8544-f42f9228b207.png)

![image](https://user-images.githubusercontent.com/12761692/72061012-f0a0ab00-32cc-11ea-8d94-540f4c7f9349.png)
